### PR TITLE
fix: worldSize => biomeScales for biome scale

### DIFF
--- a/src/main/java/wily/legacy_world_sizes/util/LegacyBiomeScale.java
+++ b/src/main/java/wily/legacy_world_sizes/util/LegacyBiomeScale.java
@@ -22,11 +22,11 @@ public record LegacyBiomeScale(ResourceLocation id, Component name, Optional<Add
 
     public static final List<ResourceKey<NormalNoise.NoiseParameters>> BIOME_SCALE_NOISE_PARAMETERS = List.of(Noises.TEMPERATURE, Noises.VEGETATION, Noises.CONTINENTALNESS, Noises.EROSION);
 
-    public static final LegacyBiomeScale SMALL = register(new LegacyBiomeScale(LegacyWorldSizes.createModLocation("small"), LWSComponents.optionName("worldSizes.small"), Optional.of(new AddOctave(2))));
+    public static final LegacyBiomeScale SMALL = register(new LegacyBiomeScale(LegacyWorldSizes.createModLocation("small"), LWSComponents.optionName("biomeScales.small"), Optional.of(new AddOctave(2))));
 
-    public static final LegacyBiomeScale MEDIUM = register(new LegacyBiomeScale(LegacyWorldSizes.createModLocation("medium"), LWSComponents.optionName("worldSizes.medium"), Optional.of(new AddOctave(1))));
+    public static final LegacyBiomeScale MEDIUM = register(new LegacyBiomeScale(LegacyWorldSizes.createModLocation("medium"), LWSComponents.optionName("biomeScales.medium"), Optional.of(new AddOctave(1))));
 
-    public static final LegacyBiomeScale CUSTOM = register(new LegacyBiomeScale(LegacyWorldSizes.createModLocation("custom"), LWSComponents.optionName("worldSizes.large"), Optional.empty()));
+    public static final LegacyBiomeScale CUSTOM = register(new LegacyBiomeScale(LegacyWorldSizes.createModLocation("custom"), LWSComponents.optionName("biomeScales.large"), Optional.empty()));
 
     public interface OctaveFunction extends Function<Integer, Integer> {
         default void applyToNoiseParameters(Holder.Reference<NormalNoise.NoiseParameters> noiseParameters) {


### PR DESCRIPTION
For some reason, the Biome Scale option used the `legacy_world_sizes.options.worldSizes.*` translation keys. This PR should fix that